### PR TITLE
Changes for opnsense

### DIFF
--- a/bin/etc-rc.conf.d-pfatt_5268AC
+++ b/bin/etc-rc.conf.d-pfatt_5268AC
@@ -1,0 +1,2 @@
+pfatt_5268AC_enable="YES"
+pfatt_5268AC_pid="/var/run/pfatt_5268AC.pid"

--- a/bin/usr-local-etc-rc.d-pfatt-5268AC
+++ b/bin/usr-local-etc-rc.d-pfatt-5268AC
@@ -1,8 +1,18 @@
 #!/bin/sh
 
-script_path="/root/bin/pfatt-5268AC.sh"
+# PROVIDE: pfatt_5268AC
+# REQUIRE: LOGIN
 
-name=`/usr/bin/basename "${script_path}"`
+. /etc/rc.subr
+
+name=pfatt_5268AC
+rcvar=pfatt_5268AC_enable
+
+local_rc_config $name
+
+: ${pfatt_5268AC_enable:="NO"}
+
+script_path="/root/bin/pfatt_5268AC.sh"
 
 rc_start() {
     ### Lock out other start signals until we are done


### PR DESCRIPTION
I made some changes as I could not get the existing script to work with the current build of opnsense.

usr-local-etc-rc.d-pfatt-5268AC should be placed in /use/local/etc/rc.d as pfatt-5268AC. It's the startup script for the /root/bin/pfatt-5268AC.sh script

etc/rc-conf.d-pfatt_5268AC should be /etc/rc.conf.d as pfatt_5268AC. This file allows control over where the pfatt-5268AC script is run at startup.

Without these changes FreeBSD refused to run the existing pfatt-5268AC-startup.sh script complaining that it was missing a name (or some such). This lead to a loss of WAN network connectivity after some time. Reading the FreeBSD RC(8) man page lead me to conclude that this was because it did not conform to the expected format. I made some adjustment based on my best understanding of the expected format while trying to minimize the number of changes made.  Note that I don't know much than what I read on that page about FreeBSD so it is possible that some of these changes are not necessary or even completely correct.

If these changes are ok I would be glad to update the existing documentation to match.
