### PR TITLE
Update gen-duid.sh and readme.md

### DIFF
--- a/bin/gen-duid.sh
+++ b/bin/gen-duid.sh
@@ -6,7 +6,7 @@ printhexstring() { awk '{l=split($0,c,"");for(i=1;i<l-1;i=i+2)printf("%s:",subst
 echo
 echo "Step 1) RG information"
 echo
-while read -p "  Manufacturer [1=Pace, 2=Motorola]: " mfg; do
+while read -p "  Manufacturer [1=Pace, 2=Motorola/Arris]: " mfg; do
         ([ "$mfg" = "1" ] || [ "$mfg" = "2" ]) && break
 done
 while read -p "  Serial number: " serial; do [ -n "$serial" ] && break; done


### PR DESCRIPTION
* Update bin/gen-duid.sh to make it more clear that Motorola and Arris use the same option.
* Update readme.md to correct the link to bin/gen-duid.sh (apparently Atom decided to get rid of some trailing spaces as well)