### PR TITLE
Correct and Update IPv6 Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ This setup assumes you have a fairly recent version of pfSense. I'm using 2.4.5.
 1. Go to _Interfaces > WAN_
 1. Enable **IPv6 Configuration Type** as _DHCP6_
 1. Scroll to _DCHP6 Client Configuration_
+1. Enable **Request only an IPv6 prefix**
 1. Enable **DHCPv6 Prefix Delegation size** as _60_
 1. Enable _Send IPv6 prefix hint_
 1. Enable _Do not wait for a RA_

--- a/README.md
+++ b/README.md
@@ -156,11 +156,14 @@ If you have additional LAN interfaces repeat these steps for each interface exce
 1. Go to _Services > DHCPv6 Server & RA_
 1. Enable DHCPv6 server on interface LAN
 1. Configure a range of ::0001 to ::ffff:ffff:ffff:fffe
-1. Configure a **Prefix Delegation Range** to _64_
+1. Leave **Prefix Delegation Range** _blank_.
+1. Configure a **Prefix Delegation Size** to _64_
 1. Save
 1. Go to the _Router Advertisements_ tab
 1. Configure **Router mode** as _Stateless DHCP_
 1. Save
+
+If you have additional LAN interfaces repeat these steps for each interface.
 
 That's it! Now your clients should be receiving public IPv6 addresses via DHCP6.
 

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ If you have additional LAN interfaces repeat these steps for each interface exce
 1. Enable DHCPv6 server on interface LAN
 1. Configure a range of ::0001 to ::ffff:ffff:ffff:fffe
 1. Leave **Prefix Delegation Range** _blank_.
-1. Configure a **Prefix Delegation Size** to _64_
+1. Configure **Prefix Delegation Size** to _64_
 1. Save
 1. Go to the _Router Advertisements_ tab
 1. Configure **Router mode** as _Stateless DHCP_


### PR DESCRIPTION
This commit contains:

- IPv6 WAN (#30): add instruction to request only an IPv6 prefix. Without this setting, the appliance will try to request an IPv6 address for itself and will fail (AT&T does not hand out addresses to routers), leaving the appliance without an IPv6 connection for itself. Toggling this on will allow the appliance to access the IPv6 internet.
- DHCPv6 Server & RA (#29) : Correct the instructions for **Prefix Delegation Range** and **Prefix Delegation Size**. Previously the instructions stated that the user should set the prefix delegation _range_ to `64`, whereas that should be left blank and prefix delegation _size_ should be set to `64`.
- Added a line after the _Services > DHCP Server & RA_ section reminding users that these instructions will need to be completed for each LAN interface that they want to have IPv6 access.