### PR TITLE
Update gen-duid.sh

### DIFF
--- a/bin/gen-duid.sh
+++ b/bin/gen-duid.sh
@@ -6,13 +6,13 @@ printhexstring() { awk '{l=split($0,c,"");for(i=1;i<l-1;i=i+2)printf("%s:",subst
 echo
 echo "Step 1) RG information"
 echo
-while read -p "  Manufacturer [1=Pace, 2=Motorola/Arris]: " mfg; do
-        ([ "$mfg" = "1" ] || [ "$mfg" = "2" ]) && break
+while read -p "  Manufacturer [1=Pace, 2=Motorola/Arris, 3=Nokia]: " mfg; do
+        ([ "$mfg" = "1" ] || [ "$mfg" = "2" ] || [ "$mfg" = "3" ]) && break
 done
 while read -p "  Serial number: " serial; do [ -n "$serial" ] && break; done
 echo
 
-[ "$mfg" = "1" ] && mfg="00D09E" || mfg="001E46"
+[ "$mfg" = "1" ] && mfg="00D09E" || [ "$mfg" = "2" ] && mfg="001E46" || [ "$mfg" = "3" ] && mfg="207852"
 echo -n "Identifier: "
 ascii2hex "$mfg-$serial" | printhexstring
 


### PR DESCRIPTION
Add support for Nokia BGW-500. This generates the proper DUID for these units.

Tested with my BGW-500 using pfSense with copper Ethernet WAN with ONT.  Not intended for use with the built-in ONT. 